### PR TITLE
Add `Error::InvalidHeaderSignature`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,10 +14,16 @@ toc::[]
 
 == {compare-url}/v0.4.1\...HEAD[Unreleased]
 
+=== Added
+
+* Add `Error::InvalidHeaderSignature`
+
 === Changed
 
 * Bump `scrypt` to v0.11
 * Bump MSRV to 1.60.0
+* Change to return `Error::InvalidHeaderSignature` if the header signature was
+  invalid
 
 == {compare-url}/v0.4.0\...v0.4.1[0.4.1] - 2022-11-09
 

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -96,7 +96,8 @@ impl Decryptor {
             let mut data = decryptor.data;
             cipher.apply_keystream(&mut data);
 
-            format::verify_signature(&decryptor.dk.mac(), &input, &decryptor.signature.as_bytes())?;
+            format::verify_signature(&decryptor.dk.mac(), &input, &decryptor.signature.as_bytes())
+                .map_err(Error::InvalidSignature)?;
 
             buf.copy_from_slice(&data);
             Ok(())

--- a/src/format.rs
+++ b/src/format.rs
@@ -137,7 +137,8 @@ impl Header {
 
     /// Verifies a HMAC-SHA-256 signature stored in this header.
     pub fn verify_signature(&mut self, key: &DerivedKey, signature: &[u8]) -> Result<(), Error> {
-        verify_signature(&key.mac(), &self.as_bytes()[..64], signature)?;
+        verify_signature(&key.mac(), &self.as_bytes()[..64], signature)
+            .map_err(Error::InvalidHeaderSignature)?;
         self.signature.copy_from_slice(signature);
         Ok(())
     }

--- a/tests/decrypt.rs
+++ b/tests/decrypt.rs
@@ -44,7 +44,7 @@ fn incorrect_password() {
     let decrypted = Decryptor::new(TEST_DATA_ENC, "passphrase")
         .and_then(Decryptor::decrypt_to_vec)
         .unwrap_err();
-    assert!(matches!(decrypted, Error::InvalidSignature(MacError)));
+    assert!(matches!(decrypted, Error::InvalidHeaderSignature(MacError)));
 }
 
 #[test]
@@ -115,11 +115,25 @@ fn invalid_checksum() {
 }
 
 #[test]
-fn invalid_signature() {
+fn invalid_header_signature() {
     let mut data = TEST_DATA_ENC.to_vec();
     let mut signature: [u8; 32] = data[64..96].try_into().unwrap();
     signature.reverse();
     data[64..96].copy_from_slice(&signature);
+    let decrypted = Decryptor::new(data, PASSWORD)
+        .and_then(Decryptor::decrypt_to_vec)
+        .unwrap_err();
+    assert!(matches!(decrypted, Error::InvalidHeaderSignature(MacError)));
+}
+
+#[test]
+fn invalid_signature() {
+    let data = TEST_DATA_ENC.to_vec();
+    let start_signature = data.len() - 32;
+    let mut data = data;
+    let mut signature: [u8; 32] = data[start_signature..].try_into().unwrap();
+    signature.reverse();
+    data[start_signature..].copy_from_slice(&signature);
     let decrypted = Decryptor::new(data, PASSWORD)
         .and_then(Decryptor::decrypt_to_vec)
         .unwrap_err();


### PR DESCRIPTION
Change to return `Error::InvalidHeaderSignature` if the header signature was invalid.