### PR TITLE
Update copyright notice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,13 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
+== {compare-url}/v0.5.1\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the comment header to the format recommended by the REUSE
+  Specification ({pull-request-url}/23[#23])
+
 == {compare-url}/v0.5.0\...v0.5.1[0.5.1] - 2023-07-04
 
 === Changed

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 #![feature(test)]
 // Lint levels of rustc.

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 #![feature(test)]
 // Lint levels of rustc.

--- a/benches/params.rs
+++ b/benches/params.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 #![feature(test)]
 // Lint levels of rustc.

--- a/examples/decrypt.rs
+++ b/examples/decrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! An example of decrypting a file from the scrypt encrypted data format.
 

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! An example of encrypting a file to the scrypt encrypted data format.
 

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! An example of reading the scrypt parameters from a file.
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2022-2023 Shun Sakai
-#
 
 alias all := default
 alias lint := clippy

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! Decrypts from the scrypt encrypted data format.
 

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! Encrypts to the scrypt encrypted data format.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! Error types for this crate.
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! Specifications of the scrypt encrypted data format.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 //! The `scryptenc` crate is an implementation of the scrypt encrypted data
 //! format.

--- a/tests/decrypt.rs
+++ b/tests/decrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 // Lint levels of rustc.
 #![forbid(unsafe_code)]

--- a/tests/encrypt.rs
+++ b/tests/encrypt.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 // Lint levels of rustc.
 #![forbid(unsafe_code)]

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2022-2023 Shun Sakai
-//
 
 // Lint levels of rustc.
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Change the comment header to the format recommended by the REUSE Specification.[^1]

[^1]: https://reuse.software/spec/#comment-headers