### PR TITLE
Rename `Error::InvalidHeaderSignature` and `Error::InvalidSignature`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,10 @@ toc::[]
 * Split `Params` from `format.rs` ({pull-request-url}/38[#38])
 * Use `StdRng` instead of `ChaCha20Rng` to generate salt
   ({pull-request-url}/38[#38])
+* Rename `Error::InvalidHeaderSignature` to `Error::InvalidHeaderMac`
+  ({pull-request-url}/40[#40])
+* Rename `Error::InvalidSignature` to `Error::InvalidMac`
+  ({pull-request-url}/40[#40])
 
 == {compare-url}/v0.5.3\...v0.6.0[0.6.0] - 2023-08-09
 

--- a/examples/decrypt.rs
+++ b/examples/decrypt.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
         .interact()
         .context("could not read password")?;
     let cipher = match scryptenc::Decryptor::new(ciphertext, password) {
-        c @ Err(scryptenc::Error::InvalidSignature(_)) => c.context("password is incorrect"),
+        c @ Err(scryptenc::Error::InvalidMac(_)) => c.context("password is incorrect"),
         c => c.with_context(|| format!("the header in {} is invalid", opt.input.display())),
     }?;
     let decrypted = cipher

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -130,7 +130,7 @@ impl Decryptor {
             cipher.apply_keystream(&mut data);
 
             format::verify_signature(&decryptor.dk.mac(), &input, &decryptor.signature.as_bytes())
-                .map_err(Error::InvalidSignature)?;
+                .map_err(Error::InvalidMac)?;
 
             buf.copy_from_slice(&data);
             Ok(())

--- a/src/format.rs
+++ b/src/format.rs
@@ -134,7 +134,7 @@ impl Header {
     /// Verifies a HMAC-SHA-256 signature stored in this header.
     pub fn verify_signature(&mut self, key: &DerivedKey, signature: &[u8]) -> Result<(), Error> {
         verify_signature(&key.mac(), &self.as_bytes()[..64], signature)
-            .map_err(Error::InvalidHeaderSignature)?;
+            .map_err(Error::InvalidHeaderMac)?;
         self.signature.copy_from_slice(signature);
         Ok(())
     }

--- a/tests/decrypt.rs
+++ b/tests/decrypt.rs
@@ -46,7 +46,7 @@ fn incorrect_password() {
     let decrypted = Decryptor::new(TEST_DATA_ENC, "passphrase")
         .and_then(Decryptor::decrypt_to_vec)
         .unwrap_err();
-    assert_eq!(decrypted, Error::InvalidHeaderSignature(MacError));
+    assert_eq!(decrypted, Error::InvalidHeaderMac(MacError));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn invalid_checksum() {
 }
 
 #[test]
-fn invalid_header_signature() {
+fn invalid_header_mac() {
     let mut data: [u8; 142] = TEST_DATA_ENC.try_into().unwrap();
     let mut signature: [u8; 32] = data[64..96].try_into().unwrap();
     signature.reverse();
@@ -128,11 +128,11 @@ fn invalid_header_signature() {
     let decrypted = Decryptor::new(data, PASSWORD)
         .and_then(Decryptor::decrypt_to_vec)
         .unwrap_err();
-    assert_eq!(decrypted, Error::InvalidHeaderSignature(MacError));
+    assert_eq!(decrypted, Error::InvalidHeaderMac(MacError));
 }
 
 #[test]
-fn invalid_signature() {
+fn invalid_mac() {
     let data: [u8; 142] = TEST_DATA_ENC.try_into().unwrap();
     let start_signature = data.len() - 32;
     let mut data = data;
@@ -142,7 +142,7 @@ fn invalid_signature() {
     let decrypted = Decryptor::new(data, PASSWORD)
         .and_then(Decryptor::decrypt_to_vec)
         .unwrap_err();
-    assert_eq!(decrypted, Error::InvalidSignature(MacError));
+    assert_eq!(decrypted, Error::InvalidMac(MacError));
 }
 
 #[test]


### PR DESCRIPTION
* Rename `Error::InvalidHeaderSignature` to `Error::InvalidHeaderMac`
* Rename `Error::InvalidSignature` to `Error::InvalidMac`