### PR TITLE
Reduce memory allocations

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 = Changelog
-:toc: macro
+:toc: preamble
 :project-url: https://github.com/sorairolake/scryptenc-rs
 :compare-url: {project-url}/compare
 :issue-url: {project-url}/issues
@@ -14,13 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
-toc::[]
-
 == {compare-url}/v0.7.1\...HEAD[Unreleased]
 
 === Changed
 
 * Re-export `hmac` crate ({pull-request-url}/51[#51])
+* Change to store the plaintext and the ciphertext as `slice` in `Encryptor`
+  and `Decryptor` ({pull-request-url}/54[#54])
 
 == {compare-url}/v0.7.0\...v0.7.1[0.7.1] - 2023-08-18
 

--- a/benches/decrypt.rs
+++ b/benches/decrypt.rs
@@ -23,7 +23,7 @@ const TEST_DATA_ENC: &[u8] = include_bytes!("../tests/data/data.txt.enc");
 #[bench]
 fn decrypt(b: &mut Bencher) {
     b.iter(|| {
-        Decryptor::new(TEST_DATA_ENC, PASSPHRASE)
+        Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap()
     });

--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -23,7 +23,7 @@ const TEST_DATA: &[u8] = include_bytes!("../tests/data/data.txt");
 fn encrypt(b: &mut Bencher) {
     b.iter(|| {
         Encryptor::with_params(
-            TEST_DATA,
+            &TEST_DATA,
             PASSPHRASE,
             Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
         )

--- a/examples/decrypt.rs
+++ b/examples/decrypt.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
         .with_prompt("Enter passphrase")
         .interact()
         .context("could not read passphrase")?;
-    let cipher = match scryptenc::Decryptor::new(ciphertext, passphrase) {
+    let cipher = match scryptenc::Decryptor::new(&ciphertext, passphrase) {
         c @ Err(scryptenc::Error::InvalidHeaderMac(_)) => c.context("passphrase is incorrect"),
         c => c.with_context(|| format!("the header in {} is invalid", opt.input.display())),
     }?;

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
         .with_confirmation("Confirm passphrase", "Passphrases mismatch, try again")
         .interact()
         .context("could not read passphrase")?;
-    let cipher = scryptenc::Encryptor::new(plaintext, passphrase);
+    let cipher = scryptenc::Encryptor::new(&plaintext, passphrase);
     let ciphertext = cipher.encrypt_to_vec();
     std::fs::write(opt.output, ciphertext)
         .with_context(|| format!("could not write the result to {}", opt.input.display()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! assert_ne!(ciphertext, data);
 //!
 //! // And decrypt it back.
-//! let plaintext = Decryptor::new(ciphertext, passphrase)
+//! let plaintext = Decryptor::new(&ciphertext, passphrase)
 //!     .and_then(Decryptor::decrypt_to_vec)
 //!     .unwrap();
 //! assert_eq!(plaintext, data);

--- a/tests/encrypt.rs
+++ b/tests/encrypt.rs
@@ -19,7 +19,7 @@ const TEST_DATA: &[u8] = include_bytes!("data/data.txt");
 fn success() {
     {
         let cipher = Encryptor::with_params(
-            TEST_DATA,
+            &TEST_DATA,
             PASSPHRASE,
             Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
         );
@@ -28,7 +28,7 @@ fn success() {
         assert_ne!(buf, TEST_DATA);
         assert_eq!(buf.len(), TEST_DATA.len() + 128);
 
-        let plaintext = Decryptor::new(buf, PASSPHRASE)
+        let plaintext = Decryptor::new(&buf, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap();
         assert_eq!(plaintext, TEST_DATA);
@@ -36,7 +36,7 @@ fn success() {
 
     {
         let ciphertext = Encryptor::with_params(
-            TEST_DATA,
+            &TEST_DATA,
             PASSPHRASE,
             Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
         )
@@ -44,7 +44,7 @@ fn success() {
         assert_ne!(ciphertext, TEST_DATA);
         assert_eq!(ciphertext.len(), TEST_DATA.len() + 128);
 
-        let plaintext = Decryptor::new(ciphertext, PASSPHRASE)
+        let plaintext = Decryptor::new(&ciphertext, PASSPHRASE)
             .and_then(Decryptor::decrypt_to_vec)
             .unwrap();
         assert_eq!(plaintext, TEST_DATA);
@@ -55,7 +55,7 @@ fn success() {
 #[should_panic(expected = "source slice length (32) does not match destination slice length (31)")]
 fn invalid_output_length() {
     let cipher = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     );
@@ -66,7 +66,7 @@ fn invalid_output_length() {
 #[test]
 fn magic_number() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -77,7 +77,7 @@ fn magic_number() {
 #[test]
 fn version() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -88,7 +88,7 @@ fn version() {
 #[test]
 fn log_n() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -99,7 +99,7 @@ fn log_n() {
 #[test]
 fn r() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -110,7 +110,7 @@ fn r() {
 #[test]
 fn p() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -121,7 +121,7 @@ fn p() {
 #[test]
 fn checksum() {
     let ciphertext = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     )
@@ -133,7 +133,7 @@ fn checksum() {
 #[test]
 fn out_len() {
     let cipher = Encryptor::with_params(
-        TEST_DATA,
+        &TEST_DATA,
         PASSPHRASE,
         Params::new(10, 8, 1, Params::RECOMMENDED_LEN).unwrap(),
     );


### PR DESCRIPTION
Change to store the plaintext and the ciphertext as `slice` in `Encryptor` and `Decryptor`.