### PR TITLE
Add a specialized `Result` type

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,11 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 == {compare-url}/v0.7.1\...HEAD[Unreleased]
 
+=== Added
+
+* Add a specialized `Result` type for read and write operations for the scrypt
+  encrypted data format ({pull-request-url}/56[#56])
+
 === Changed
 
 * Re-export `hmac` crate ({pull-request-url}/51[#51])

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 
 //! Error types for this crate.
 
-use core::fmt;
+use core::{fmt, result};
 
 use hmac::digest::MacError;
 use scrypt::errors::InvalidParams;
@@ -66,6 +66,36 @@ impl From<InvalidParams> for Error {
         Self::InvalidParams(source)
     }
 }
+
+/// A specialized [`Result`](result::Result) type for read and write operations
+/// for the scrypt encrypted data format.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "alloc")]
+/// # {
+/// use scryptenc::{Decryptor, Encryptor};
+///
+/// fn encrypt(plaintext: &[u8], passphrase: &[u8]) -> Vec<u8> {
+///     Encryptor::new(&plaintext, passphrase).encrypt_to_vec()
+/// }
+///
+/// fn decrypt(ciphertext: &[u8], passphrase: &[u8]) -> scryptenc::Result<Vec<u8>> {
+///     Decryptor::new(&ciphertext, passphrase).and_then(|c| c.decrypt_to_vec())
+/// }
+///
+/// let data = b"Hello, world!\n";
+/// let passphrase = b"passphrase";
+///
+/// let ciphertext = encrypt(data, passphrase);
+/// assert_ne!(ciphertext, data);
+///
+/// let plaintext = decrypt(&ciphertext, passphrase).unwrap();
+/// assert_eq!(plaintext, data);
+/// # }
+/// ```
+pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(test)]
 mod tests {
@@ -317,6 +347,20 @@ mod tests {
         assert_eq!(
             Error::from(InvalidParams),
             Error::InvalidParams(InvalidParams)
+        );
+    }
+
+    #[test]
+    fn result_type() {
+        use core::any;
+
+        assert_eq!(
+            any::type_name::<Result<()>>(),
+            any::type_name::<result::Result<(), Error>>()
+        );
+        assert_eq!(
+            any::type_name::<Result<u8>>(),
+            any::type_name::<result::Result<u8, Error>>()
         );
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -18,7 +18,10 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use scrypt::Params;
 use sha2::{Digest, Sha256};
 
-use crate::{error::Error, Aes256Ctr128BE, HmacSha256, HmacSha256Key, HmacSha256Output};
+use crate::{
+    error::{Error, Result},
+    Aes256Ctr128BE, HmacSha256, HmacSha256Key, HmacSha256Output,
+};
 
 /// A type alias for magic number of the scrypt encrypted data format.
 type MagicNumber = [u8; 6];
@@ -99,7 +102,7 @@ impl Header {
     }
 
     /// Parses `data` into the header.
-    pub fn parse(data: &[u8]) -> Result<Self, Error> {
+    pub fn parse(data: &[u8]) -> Result<Self> {
         if data.len() < Self::SIZE + <HmacSha256 as OutputSizeUser>::OutputSize::USIZE {
             return Err(Error::InvalidLength);
         }
@@ -148,7 +151,7 @@ impl Header {
     }
 
     /// Verifies a SHA-256 checksum stored in this header.
-    pub fn verify_checksum(&mut self, checksum: &[u8]) -> Result<(), Error> {
+    pub fn verify_checksum(&mut self, checksum: &[u8]) -> Result<()> {
         self.compute_checksum();
         if self.checksum == checksum {
             Ok(())
@@ -166,7 +169,7 @@ impl Header {
     }
 
     /// Verifies a HMAC-SHA-256 stored in this header.
-    pub fn verify_mac(&mut self, key: &HeaderMacKey, tag: &HeaderMacOutput) -> Result<(), Error> {
+    pub fn verify_mac(&mut self, key: &HeaderMacKey, tag: &HeaderMacOutput) -> Result<()> {
         let mut mac =
             HmacSha256::new_from_slice(key).expect("HMAC-SHA-256 key size should be 256 bits");
         mac.update(&self.as_bytes()[..64]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,12 @@ use hmac::{
 };
 use sha2::Sha256;
 
-pub use crate::{decrypt::Decryptor, encrypt::Encryptor, error::Error, params::Params};
+pub use crate::{
+    decrypt::Decryptor,
+    encrypt::Encryptor,
+    error::{Error, Result},
+    params::Params,
+};
 
 /// A type alias for AES-256-CTR.
 type Aes256Ctr128BE = Ctr128BE<Aes256>;

--- a/src/params.rs
+++ b/src/params.rs
@@ -4,7 +4,7 @@
 
 //! The scrypt parameters.
 
-use crate::{error::Error, format::Header};
+use crate::{error::Result, format::Header};
 
 /// The scrypt parameters used for the encrypted data.
 #[derive(Clone, Copy, Debug)]
@@ -31,7 +31,7 @@ impl Params {
     ///
     /// assert!(Params::new(ciphertext).is_ok());
     /// ```
-    pub fn new(ciphertext: impl AsRef<[u8]>) -> Result<Self, Error> {
+    pub fn new(ciphertext: impl AsRef<[u8]>) -> Result<Self> {
         let params = Header::parse(ciphertext.as_ref()).map(|h| h.params())?;
         Ok(Self(params))
     }


### PR DESCRIPTION
This is for read and write operations for the scrypt encrypted data format.