### PR TITLE
refactor: Change type of `--passphrase-from-env`

### DIFF
--- a/crates/cli/CHANGELOG.adoc
+++ b/crates/cli/CHANGELOG.adoc
@@ -19,6 +19,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/scryptenc-cli-v0.7.12\...HEAD[Unreleased]
+
+=== Changed
+
+* Change `--passphrase-from-env` to take an UTF-8 string as an environment
+  variable key ({pull-request-url}/407[#407])
+
 == {compare-url}/scryptenc-cli-v0.7.11\...scryptenc-cli-v0.7.12[0.7.12] - 2024-04-17
 
 === Changed

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::{
-    ffi::OsString,
     fmt,
     io::{self, Write},
     ops::Deref,
@@ -179,7 +178,7 @@ pub struct Encrypt {
     /// Note that storing a passphrase in an environment variable can be a
     /// security risk.
     #[arg(long, value_name("VAR"), group("passphrase"))]
-    pub passphrase_from_env: Option<OsString>,
+    pub passphrase_from_env: Option<String>,
 
     /// Read the passphrase from the file.
     ///
@@ -263,7 +262,7 @@ pub struct Decrypt {
     /// Note that storing a passphrase in an environment variable can be a
     /// security risk.
     #[arg(long, value_name("VAR"), group("passphrase"))]
-    pub passphrase_from_env: Option<OsString>,
+    pub passphrase_from_env: Option<String>,
 
     /// Read the passphrase from the file.
     ///

--- a/crates/cli/src/passphrase.rs
+++ b/crates/cli/src/passphrase.rs
@@ -4,7 +4,6 @@
 
 use std::{
     env,
-    ffi::OsStr,
     fs::File,
     io::{self, BufRead, BufReader},
     path::Path,
@@ -45,7 +44,7 @@ pub fn read_passphrase_from_tty_once() -> anyhow::Result<String> {
 }
 
 /// Reads the passphrase from the environment variable.
-pub fn read_passphrase_from_env(key: &OsStr) -> anyhow::Result<String> {
+pub fn read_passphrase_from_env(key: &str) -> anyhow::Result<String> {
     env::var(key).context("could not read passphrase from environment variable")
 }
 


### PR DESCRIPTION
Change it to take an UTF-8 string as an environment variable key.

## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CODE_OF_CONDUCT.md
