### PR TITLE
feat: Make `Error` trait available in `no_std` mode

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         toolchain:
-          - 1.74.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         include:
           - target: x86_64-unknown-linux-gnu
@@ -66,7 +66,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         toolchain:
-          - 1.74.0
+          - 1.81.0
           - stable
         include:
           - target: x86_64-unknown-linux-gnu
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - name: Checkout code
@@ -137,7 +137,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74.0
+          - 1.81.0
           - stable
     steps:
       - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,6 @@ dependencies = [
  "dialoguer",
  "fraction",
  "humantime",
- "once_cell",
  "predicates",
  "scryptenc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/*"]
 [workspace.package]
 authors = ["Shun Sakai <sorairolake@protonmail.ch>"]
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.81.0"
 homepage = "https://sorairolake.github.io/scryptenc-rs/"
 repository = "https://github.com/sorairolake/scryptenc-rs"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-msrv = "1.74.0"
+msrv = "1.81.0"

--- a/crates/cli/BUILD.adoc
+++ b/crates/cli/BUILD.adoc
@@ -7,7 +7,7 @@
 == Prerequisites
 
 .To build *rscrypt*, you will need the following dependencies
-* https://doc.rust-lang.org/stable/cargo/[Cargo] (v1.74.0 or later)
+* https://doc.rust-lang.org/stable/cargo/[Cargo] (v1.81.0 or later)
 
 .To build man pages, you will need the following additional dependencies
 * https://asciidoctor.org/[Asciidoctor]

--- a/crates/cli/CHANGELOG.adoc
+++ b/crates/cli/CHANGELOG.adoc
@@ -19,6 +19,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/scryptenc-cli-v0.7.13\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.81.0 ({pull-request-url}/432[#432])
+
 == {compare-url}/scryptenc-cli-v0.7.12\...scryptenc-cli-v0.7.13[0.7.13] - 2024-08-04
 
 === Changed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,7 +32,6 @@ clap_complete_nushell = "4.5.4"
 dialoguer.workspace = true
 fraction = { version = "0.15.3", default-features = false }
 humantime = "2.1.0"
-once_cell = "1.20.2"
 scryptenc = { version = "0.9.9", path = "../scryptenc" }
 serde = { version = "1.0.214", features = ["derive"], optional = true }
 serde_json = { version = "1.0.132", optional = true }

--- a/crates/cli/src/params.rs
+++ b/crates/cli/src/params.rs
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::time::{Duration, Instant};
+use std::{
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context;
 use byte_unit::UnitType;
 use fraction::{Fraction, GenericFraction, ToPrimitive};
-use once_cell::sync::Lazy;
 use scryptenc::scrypt;
 use sysinfo::System;
 use thiserror::Error;
@@ -18,8 +20,8 @@ type U128Fraction = GenericFraction<u128>;
 
 const SECOND: Duration = Duration::from_secs(1);
 
-static SYSTEM: Lazy<System> = Lazy::new(System::new_all);
-static OPERATIONS_PER_SECOND: Lazy<u64> = Lazy::new(get_scrypt_performance);
+static SYSTEM: LazyLock<System> = LazyLock::new(System::new_all);
+static OPERATIONS_PER_SECOND: LazyLock<u64> = LazyLock::new(get_scrypt_performance);
 
 /// The error type for this module.
 #[derive(Debug, Error)]

--- a/crates/scryptenc/CHANGELOG.adoc
+++ b/crates/scryptenc/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/scryptenc-v0.9.9\...HEAD[Unreleased]
+
+=== Changed
+
+* Make `Error` trait available in `no_std` mode ({pull-request-url}/432[#432])
+* Bump MSRV to 1.81.0 ({pull-request-url}/432[#432])
+
 == {compare-url}/scryptenc-v0.9.8\...scryptenc-v0.9.9[0.9.9] - 2024-10-19
 
 === Fixed

--- a/crates/scryptenc/README.md
+++ b/crates/scryptenc/README.md
@@ -50,7 +50,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Source code
 

--- a/crates/scryptenc/src/error.rs
+++ b/crates/scryptenc/src/error.rs
@@ -4,7 +4,7 @@
 
 //! Error types for this crate.
 
-use core::{fmt, result};
+use core::{error, fmt, result};
 
 use hmac::digest::MacError;
 use scrypt::errors::InvalidParams;
@@ -50,10 +50,9 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl error::Error for Error {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::InvalidParams(err) => Some(err),
             Self::InvalidHeaderMac(err) | Self::InvalidMac(err) => Some(err),
@@ -324,10 +323,9 @@ mod tests {
         assert_eq!(format!("{}", Error::InvalidMac(MacError)), "invalid MAC");
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn source() {
-        use std::error::Error as _;
+        use error::Error as _;
 
         assert!(Error::InvalidLength.source().is_none());
         assert!(Error::InvalidMagicNumber.source().is_none());

--- a/crates/scryptenc/src/lib.rs
+++ b/crates/scryptenc/src/lib.rs
@@ -88,8 +88,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod decrypt;
 mod encrypt;

--- a/crates/wasm/CHANGELOG.adoc
+++ b/crates/wasm/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/scryptenc-wasm-v0.2.3\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.81.0 ({pull-request-url}/432[#432])
+
 == {compare-url}/scryptenc-wasm-v0.2.2\...scryptenc-wasm-v0.2.3[0.2.3] - 2024-02-28
 
 === Changed

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -41,7 +41,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.74.0.
+The minimum supported Rust version (MSRV) of this library is v1.81.0.
 
 ## Source code
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Merging this requires that the low-level error types implement [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html) trait.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #418

## Additional context

<!-- If you have any other context, describe them here. -->
Wait until at least Rust 1.83 is released before merging this.

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CODE_OF_CONDUCT.md
