### PR TITLE
fix: Fix `Encryptor::encrypt` and `Decryptor::decrypt`

### DIFF
--- a/crates/scryptenc/CHANGELOG.adoc
+++ b/crates/scryptenc/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/scryptenc-v0.9.8\...HEAD[Unreleased]
+
+=== Fixed
+
+* Change `Encryptor::encrypt` and `Decryptor::decrypt` to take the buffer to
+  write to as a mutable reference ({pull-request-url}/457[#457])
+
 == {compare-url}/scryptenc-v0.9.7\...scryptenc-v0.9.8[0.9.8] - 2024-07-31
 
 === Added

--- a/crates/scryptenc/src/decrypt.rs
+++ b/crates/scryptenc/src/decrypt.rs
@@ -101,7 +101,7 @@ impl<'c> Decryptor<'c> {
     /// cipher.decrypt(&mut buf).unwrap();
     /// # assert_eq!(buf, data.as_slice());
     /// ```
-    pub fn decrypt(&self, mut buf: impl AsMut<[u8]>) -> Result<()> {
+    pub fn decrypt(&self, buf: &mut (impl AsMut<[u8]> + ?Sized)) -> Result<()> {
         let inner = |decryptor: &Self, buf: &mut [u8]| -> Result<()> {
             fn verify_mac(data: &[u8], key: &HmacSha256Key, tag: &HmacSha256Output) -> Result<()> {
                 let mut mac = HmacSha256::new_from_slice(key)

--- a/crates/scryptenc/src/encrypt.rs
+++ b/crates/scryptenc/src/encrypt.rs
@@ -106,7 +106,7 @@ impl<'m> Encryptor<'m> {
     /// cipher.encrypt(&mut buf);
     /// # assert_ne!(buf, data.as_slice());
     /// ```
-    pub fn encrypt(&self, mut buf: impl AsMut<[u8]>) {
+    pub fn encrypt(&self, buf: &mut (impl AsMut<[u8]> + ?Sized)) {
         let inner = |encryptor: &Self, buf: &mut [u8]| {
             fn compute_mac(data: &[u8], key: &HmacSha256Key) -> HmacSha256Output {
                 let mut mac = HmacSha256::new_from_slice(key)


### PR DESCRIPTION
Change to take the buffer to write to as a mutable reference.

## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CODE_OF_CONDUCT.md
