### PR TITLE
feat!: Use pass-by-value with types that implement `Copy`

### DIFF
--- a/crates/scryptenc/CHANGELOG.adoc
+++ b/crates/scryptenc/CHANGELOG.adoc
@@ -19,6 +19,10 @@ project adheres to https://semver.org/[Semantic Versioning].
 === Changed
 
 * Bump MSRV to 1.88.0 ({pull-request-url}/744[#744])
+* Change getters for types that implement the `Copy` trait to pass-by-value
+  ({pull-request-url}/822[#822])
+* Change to consume instances when encrypting and decrypting
+  ({pull-request-url}/822[#822])
 
 == {compare-url}/scryptenc-v0.9.10\...scryptenc-v0.10.0[0.10.0] - 2025-07-28
 

--- a/crates/scryptenc/benches/decrypt.rs
+++ b/crates/scryptenc/benches/decrypt.rs
@@ -17,7 +17,7 @@ static TEST_DATA_ENC: &[u8] = include_bytes!("../tests/data/data.txt.scrypt");
 fn decrypt(b: &mut Bencher) {
     b.iter(|| {
         Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
-            .and_then(|c| c.decrypt_to_vec())
+            .and_then(Decryptor::decrypt_to_vec)
             .unwrap()
     });
 }

--- a/crates/scryptenc/src/decrypt.rs
+++ b/crates/scryptenc/src/decrypt.rs
@@ -104,8 +104,8 @@ impl<'c> Decryptor<'c> {
     /// cipher.decrypt(&mut buf).unwrap();
     /// # assert_eq!(buf, *data);
     /// ```
-    pub fn decrypt<B: AsMut<[u8]> + ?Sized>(&self, buf: &mut B) -> Result<()> {
-        let inner = |decryptor: &Self, buf: &mut [u8]| -> Result<()> {
+    pub fn decrypt<B: AsMut<[u8]> + ?Sized>(self, buf: &mut B) -> Result<()> {
+        let inner = |decryptor: Self, buf: &mut [u8]| -> Result<()> {
             fn verify_mac(data: &[u8], key: &HmacSha256Key, tag: &HmacSha256Output) -> Result<()> {
                 let mut mac = HmacSha256::new_from_slice(key)
                     .expect("HMAC-SHA-256 key size should be 256 bits");
@@ -144,7 +144,7 @@ impl<'c> Decryptor<'c> {
     /// # assert_eq!(plaintext, data);
     /// ```
     #[cfg(feature = "alloc")]
-    pub fn decrypt_to_vec(&self) -> Result<Vec<u8>> {
+    pub fn decrypt_to_vec(self) -> Result<Vec<u8>> {
         let mut buf = vec![u8::default(); self.out_len()];
         self.decrypt(&mut buf)?;
         Ok(buf)
@@ -199,5 +199,5 @@ impl<'c> Decryptor<'c> {
 /// ```
 #[cfg(feature = "alloc")]
 pub fn decrypt(ciphertext: impl AsRef<[u8]>, passphrase: impl AsRef<[u8]>) -> Result<Vec<u8>> {
-    Decryptor::new(&ciphertext, passphrase).and_then(|c| c.decrypt_to_vec())
+    Decryptor::new(&ciphertext, passphrase).and_then(Decryptor::decrypt_to_vec)
 }

--- a/crates/scryptenc/src/encrypt.rs
+++ b/crates/scryptenc/src/encrypt.rs
@@ -109,8 +109,8 @@ impl<'m> Encryptor<'m> {
     /// cipher.encrypt(&mut buf);
     /// # assert_ne!(buf.as_slice(), data);
     /// ```
-    pub fn encrypt<B: AsMut<[u8]> + ?Sized>(&self, buf: &mut B) {
-        let inner = |encryptor: &Self, buf: &mut [u8]| {
+    pub fn encrypt<B: AsMut<[u8]> + ?Sized>(self, buf: &mut B) {
+        let inner = |encryptor: Self, buf: &mut [u8]| {
             fn compute_mac(data: &[u8], key: &HmacSha256Key) -> HmacSha256Output {
                 let mut mac = HmacSha256::new_from_slice(key)
                     .expect("HMAC-SHA-256 key size should be 256 bits");
@@ -148,7 +148,7 @@ impl<'m> Encryptor<'m> {
     /// ```
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub fn encrypt_to_vec(&self) -> Vec<u8> {
+    pub fn encrypt_to_vec(self) -> Vec<u8> {
         let mut buf = vec![u8::default(); self.out_len()];
         self.encrypt(&mut buf);
         buf

--- a/crates/scryptenc/src/params.rs
+++ b/crates/scryptenc/src/params.rs
@@ -61,7 +61,7 @@ impl Params {
     /// assert_eq!(params.log_n(), 10);
     /// ```
     #[must_use]
-    pub const fn log_n(&self) -> u8 {
+    pub const fn log_n(self) -> u8 {
         self.log_n
     }
 
@@ -78,8 +78,8 @@ impl Params {
     /// assert_eq!(params.n(), 1024);
     /// ```
     #[must_use]
-    pub const fn n(&self) -> u64 {
-        1 << self.log_n
+    pub const fn n(self) -> u64 {
+        1 << self.log_n()
     }
 
     /// Gets `r` parameter.
@@ -95,7 +95,7 @@ impl Params {
     /// assert_eq!(params.r(), 8);
     /// ```
     #[must_use]
-    pub const fn r(&self) -> u32 {
+    pub const fn r(self) -> u32 {
         self.r
     }
 
@@ -112,7 +112,7 @@ impl Params {
     /// assert_eq!(params.p(), 1);
     /// ```
     #[must_use]
-    pub const fn p(&self) -> u32 {
+    pub const fn p(self) -> u32 {
         self.p
     }
 }

--- a/crates/scryptenc/tests/decrypt.rs
+++ b/crates/scryptenc/tests/decrypt.rs
@@ -23,7 +23,7 @@ fn success() {
 #[test]
 fn success_to_vec() {
     let plaintext = Decryptor::new(&TEST_DATA_ENC, PASSPHRASE)
-        .and_then(|c| c.decrypt_to_vec())
+        .and_then(Decryptor::decrypt_to_vec)
         .unwrap();
     assert_eq!(plaintext, TEST_DATA);
 }

--- a/crates/scryptenc/tests/encrypt.rs
+++ b/crates/scryptenc/tests/encrypt.rs
@@ -68,7 +68,7 @@ fn success_to_vec() {
     assert_eq!(params.p(), 16);
 
     let plaintext = Decryptor::new(&ciphertext, PASSPHRASE)
-        .and_then(|c| c.decrypt_to_vec())
+        .and_then(Decryptor::decrypt_to_vec)
         .unwrap();
     assert_eq!(plaintext, TEST_DATA);
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
These types implement the `Copy` trait, and are small enough to be more efficient to always pass by value.

Also, I think `Encryptor` and `Decryptor` should be consumed when encrypting and decrypting, so I change them to consume them.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/scryptenc-rs/blob/develop/CODE_OF_CONDUCT.md
